### PR TITLE
fix: Exempt pytest from exclude-newer to prevent Renovate PR loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,4 @@ dev = [
 
 [tool.uv]
 exclude-newer = "1 week"
+exclude-newer-package = { pytest = false }


### PR DESCRIPTION
Exempt pytest from the relative `exclude-newer` constraint to stop Renovate from creating duplicate security PRs.